### PR TITLE
FIX (OAuth2): remove shared state to prevent wrong user data on concurrent login

### DIFF
--- a/src/main/java/com/toeic/toeic_practice_backend/security/oauth2/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/toeic/toeic_practice_backend/security/oauth2/OAuth2LoginSuccessHandler.java
@@ -2,6 +2,7 @@ package com.toeic.toeic_practice_backend.security.oauth2;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
@@ -14,7 +15,6 @@ import org.springframework.security.web.authentication.SimpleUrlAuthenticationSu
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import com.toeic.toeic_practice_backend.domain.entity.Role;
 import com.toeic.toeic_practice_backend.domain.entity.User;
 import com.toeic.toeic_practice_backend.service.RoleService;
 import com.toeic.toeic_practice_backend.service.UserService;
@@ -36,15 +36,15 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
     private final Encoder encoder;
     @Value("${client.url}")
     private String clientUrl;
-    private User user = null;
-    private String message = "Đăng nhập thành công";
-    private Integer status = HttpStatus.OK.value();
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
             Authentication authentication) throws IOException, ServletException {
-    	
+
         String targetUrl = this.clientUrl + "/oauth2/redirect";
+        Integer status = HttpStatus.OK.value();
+        String message = "Đăng nhập thành công";
+        User user = null;
 
         DefaultOAuth2User principal = (DefaultOAuth2User) authentication.getPrincipal();
         Map<String, Object> attributes = principal.getAttributes();
@@ -52,56 +52,58 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         String avatar = attributes.getOrDefault("picture", "").toString();
         log.info("Login account: " + email);
 
-        this.userService.getUserByEmail(email).ifPresentOrElse(user -> {
-            if (!user.isActive()) {
-                this.message = "Tài khoản của bạn đang bị khóa";
-                this.status = HttpStatus.FORBIDDEN.value();
+        Optional<User> optionalUser = this.userService.getUserByEmail(email);
+        if (optionalUser.isPresent()) {
+            User existingUser = optionalUser.get();
+            if (!existingUser.isActive()) {
+                log.warn("Account is blocked: {}", email);
+                message = "BLOCKED ACCOUNT";
+                status = HttpStatus.FORBIDDEN.value();
             } else {
-                this.user = user;
+                user = existingUser;
             }
-        }, () -> {
-            User user = new User();
-            user.setEmail(email);
-            user.setAvatar(avatar);
-            user.setActive(true);
-            Role role = roleService.getRoleByName("USER");
-            user.setRole(role);
-            this.user = this.userService.saveUser(user);
-        });
-        if (this.user != null) {
+        } else {
+            User newUser = new User();
+            newUser.setEmail(email);
+            newUser.setAvatar(avatar);
+            newUser.setActive(true);
+            newUser.setRole(roleService.getRoleByName("USER"));
+            user = userService.saveUser(newUser);
+        }
+
+        if (user != null) {
             String accessToken = this.jwtTokenUtils.createAccessToken(user);
             String refreshToken = this.jwtTokenUtils.createRefreshToken(user);
-         // Set refresh token to cookie
+            user.setRefreshToken(refreshToken);
+            userService.saveUser(user);
             ResponseCookie responseCookie = ResponseCookie.from("refresh_token", refreshToken)
                     .httpOnly(true)
                     .secure(true)
                     .path("/")
                     .maxAge(jwtTokenUtils.getRefreshTokenExpiration())
                     .build();
-            this.user.setRefreshToken(refreshToken);
-            this.user = this.userService.saveUser(user);
             response.addHeader("Set-Cookie", responseCookie.toString());
-         // Save the user's authentication into SecurityContextHolder
-	            Authentication newAuth = new UsernamePasswordAuthenticationToken(
-	                    this.user.getEmail(), null, authentication.getAuthorities());
-	            System.out.println("success: "+ newAuth);
-	            SecurityContextHolder.getContext().setAuthentication(newAuth);
+
+            Authentication newAuth = new UsernamePasswordAuthenticationToken(
+                    user.getEmail(), null, authentication.getAuthorities());
+            SecurityContextHolder.getContext().setAuthentication(newAuth);
+
             targetUrl = UriComponentsBuilder.fromUriString(targetUrl)
-                    .queryParam("status", this.status)
-                    .queryParam("iduser", this.user.getId())
+                    .queryParam("status", status)
+                    .queryParam("iduser", user.getId())
                     .queryParam("token", accessToken)
-                    .queryParam("email", this.encoder.encode(this.user.getEmail()))
-                    .queryParam("avatar", this.encoder.encode(this.user.getAvatar()))
-                    .queryParam("role", this.user.getRole().getName())
+                    .queryParam("email", encoder.encode(user.getEmail()))
+                    .queryParam("avatar", encoder.encode(user.getAvatar()))
+                    .queryParam("role", user.getRole().getName())
                     .build().toUriString();
-            log.info("Login account success: " + email);
         } else {
             targetUrl = UriComponentsBuilder.fromUriString(targetUrl)
-                    .queryParam("status", this.status)
-                    .queryParam("message", this.message)
+                    .queryParam("status", status)
+                    .queryParam("message", message)
                     .build().toUriString();
-            log.error("Login account failed: " + email);
         }
+
         response.sendRedirect(targetUrl);
     }
+
 }


### PR DESCRIPTION
- Removed field-level 'user', 'status', and 'message' to avoid shared state in singleton bean

- Now using local variables inside 'onAuthenticationSuccess' for thread safety